### PR TITLE
Use v3.3 as default facebook version api

### DIFF
--- a/src/interfaces/facebook.js
+++ b/src/interfaces/facebook.js
@@ -20,7 +20,7 @@ class Facebook extends Interface {
     this.canSend = false;
 
     this.setConfig({
-      version: 'v3.0',
+      version: 'v3.3',
       parseUrl: true,
       reconnect: true,
     });


### PR DESCRIPTION
User's can still override the default by setting the config object manually. This just sets us up to until May 2021 for expiration